### PR TITLE
Fix wrong RTT calculation in TIMELY

### DIFF
--- a/src/applications/model/seq-ts-header.cc
+++ b/src/applications/model/seq-ts-header.cc
@@ -36,6 +36,8 @@ SeqTsHeader::SeqTsHeader()
       m_ts(Simulator::Now().GetTimeStep())
 {
     NS_LOG_FUNCTION(this);
+    if (IntHeader::mode == 1)
+        ih.ts = Simulator::Now().GetTimeStep();
 }
 
 void


### PR DESCRIPTION
Refer to: https://github.com/inet-tub/ns3-datacenter/blob/master/simulator/ns-3.39/src/network/utils/seq-ts-header.cc#L37-L38

Test with DLRM payloads.

Before:

```plain
sys[0] finished, 35126038 cycles
sys[1] finished, 35126039 cycles
sys[7] finished, 35126039 cycles
sys[6] finished, 35126039 cycles
sys[5] finished, 35126039 cycles
sys[4] finished, 35126039 cycles
sys[3] finished, 35126039 cycles
sys[2] finished, 35126039 cycles
```

After:

```plain
sys[6] finished, 13383757 cycles
sys[2] finished, 13386182 cycles
sys[4] finished, 13386609 cycles
sys[7] finished, 13387494 cycles
sys[0] finished, 13389843 cycles
sys[5] finished, 13391015 cycles
sys[3] finished, 13391045 cycles
sys[1] finished, 14249000 cycles
```