### PR TITLE
Fix No Return Error

### DIFF
--- a/scratch/common.h
+++ b/scratch/common.h
@@ -320,6 +320,7 @@ uint64_t get_nic_rate(NodeContainer &n) {
       return DynamicCast<QbbNetDevice>(n.Get(i)->GetDevice(1))
           ->GetDataRate()
           .GetBitRate();
+  return 0;
 }
 
 bool ReadConf(string network_configuration) {

--- a/scratch/common.h
+++ b/scratch/common.h
@@ -320,6 +320,7 @@ uint64_t get_nic_rate(NodeContainer &n) {
       return DynamicCast<QbbNetDevice>(n.Get(i)->GetDevice(1))
           ->GetDataRate()
           .GetBitRate();
+  // TODO: Complain if you cannot find the NIC rate.
   return 0;
 }
 


### PR DESCRIPTION
function `get_nic_rate()` in `scratch/common.h` has no return function and can cause some compilers to complain. Adding a return 0 at the end fixes it