### PR TITLE
Support parallel RDMA route entries

### DIFF
--- a/scratch/common.h
+++ b/scratch/common.h
@@ -113,6 +113,7 @@ struct Interface {
   Interface() : idx(0), up(false) {}
 };
 map<Ptr<Node>, map<Ptr<Node>, Interface>> nbr2if;
+map<Ptr<Node>, map<Ptr<Node>, vector<uint32_t>>> nbr2ifs;
 // Mapping destination to next hop for each node: <node, <dest, <nexthop0, ...>
 // > >
 map<Ptr<Node>, map<Ptr<Node>, vector<Ptr<Node>>>> nextHop;
@@ -276,12 +277,13 @@ void SetRoutingEntries() {
       vector<Ptr<Node>> nexts = j->second;
       for (int k = 0; k < (int)nexts.size(); k++) {
         Ptr<Node> next = nexts[k];
-        uint32_t interface = nbr2if[node][next].idx;
-        if (node->GetNodeType() == 1)
-          DynamicCast<SwitchNode>(node)->AddTableEntry(dstAddr, interface);
-        else {
-          node->GetObject<RdmaDriver>()->m_rdma->AddTableEntry(dstAddr,
-                                                               interface);
+        for (uint32_t interface : nbr2ifs[node][next]) {
+          if (node->GetNodeType() == 1)
+            DynamicCast<SwitchNode>(node)->AddTableEntry(dstAddr, interface);
+          else {
+            node->GetObject<RdmaDriver>()->m_rdma->AddTableEntry(dstAddr,
+                                                                 interface);
+          }
         }
       }
     }
@@ -688,6 +690,8 @@ bool SetupNetwork(void (*qp_finish)(FILE *, Ptr<RdmaQueuePair>)) {
             .GetTimeStep();
     nbr2if[dnode][snode].bw =
         DynamicCast<QbbNetDevice>(d.Get(1))->GetDataRate().GetBitRate();
+    nbr2ifs[snode][dnode].push_back(nbr2if[snode][dnode].idx);
+    nbr2ifs[dnode][snode].push_back(nbr2if[dnode][snode].idx);
 
     // This is just to set up the connectivity between nodes. The IP addresses
     // are useless
@@ -900,6 +904,7 @@ bool SetupNetwork(void (*qp_finish)(FILE *, Ptr<RdmaQueuePair>)) {
 
   // schedule link down
   if (link_down_time > 0) {
+    if (nbr2ifs[n.Get(link_down_A)][n.Get(link_down_B)].size() > 1) { fprintf(stderr, "LINK_DOWN does not support parallel interfaces\n"); return false; }
     Simulator::Schedule(Seconds(2) + MicroSeconds(link_down_time),
                         &TakeDownLink, n, n.Get(link_down_A),
                         n.Get(link_down_B));


### PR DESCRIPTION
## 变更

- 为同一 next hop 安装全部平行物理 interface，而不是只保留最后一条。
- 保留现有 `nbr2if` 图语义，不修改 RDMA、Qbb、拥塞控制或 ECMP hash。
- 对尚未支持逐 lane 状态的 Q>1 `LINK_DOWN` 直接 fail-fast。

## 原因

ASTRA direct Clos 中，同一 GPU-switch pair 可以有多条物理链路。当前单值 `nbr2if` 会覆盖先前 interface，导致 route table 只使用最后一条链路。该补丁只补齐 route-entry 枚举，使现有 RDMA/switch hash 能选择全部物理接口。

## 验证

- `scratch_AstraSimNetwork` 编译通过。
- 上层 N/M/Q/R 基准的 9 个 Q>1/Q=1 topology 完成 native trace 路径校准；27/27 个真实性能 case 成功。
- Q=1 feature-off smoke 的 FCT 与补丁前逐字节一致。

范围限定为无动态链路故障的 single-stage direct Clos；逐 lane failure/reroute 不在本 PR 范围。

updated at 2026/07/11 00:22
implemented by codex local
